### PR TITLE
Example docker files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# syntax=docker/dockerfile:1
+
+FROM python:3.8-slim-buster
+
+WORKDIR /app
+
+COPY requirements.txt requirements.txt
+RUN pip3 install -r requirements.txt
+
+COPY main.py main.py
+COPY scripts scripts
+
+VOLUME config.json
+
+CMD ["python3", "main.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.8'
+
+services:
+  app:
+    image: tidyauth:latest
+    volumes:
+      - /home/tazard/code/tidyauth/config.json:/app/config.json
+    ports:
+      - 5000:5000


### PR DESCRIPTION
Example of dockerising tidyauth.

Tested locally and seems to work.

Docker image won't contain config. Store that on system somewhere and provide path in volume in docker compose file.

After building container on dev PC can save to file like:

```
docker save tidyauth:latest | gzip > tidyauth_docker_image.tar.gz
```

Then load like:

```
gunzip -c tidyauth_docker_image.tar.gz | docker load
```